### PR TITLE
added hideSelectionAfterCopy function, updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The ranges are specified in the `settings.json` file for entry `selectby.regexes
     * `backwardInclude`: should the matched **backward** search text be part of the selection (default: true)
     * `forwardInclude`: should the matched **forward** search text be part of the selection (default: true)
     * `copyToClipboard`: copy the selection to the clipboard (default: false)
+    * `hideSelectionAfterCopy`: hides the copied selection in the editor, and keeps the cursor at its current location. Only works if `copyToClipboard` is true. (default: false)
 
 If newline characters are part of the regular expression you can determine if it is part of the selection (see example `regex2`).
 

--- a/extension.js
+++ b/extension.js
@@ -42,10 +42,17 @@ function activate(context) {
         break;
       }
     }
-    if (getProperty(search, "copyToClipboard", false)) {
+    var copyToClipboard = getProperty(search, "copyToClipboard", false);
+    var hideSelectionAfterCopy = getProperty(search, "hideSelectionAfterCopy", false);
+
+    if (copyToClipboard) {
       vscode.env.clipboard.writeText(docText.substring(selectStart, selectEnd)).then((v)=>v, (v)=>null);
     }
-    editor.selection = new vscode.Selection(editor.document.positionAt(selectStart), editor.document.positionAt(selectEnd));
+    if (hideSelectionAfterCopy && copyToClipboard) {
+      editor.selection = new vscode.Selection(editor.document.positionAt(offsetCursor), editor.document.positionAt(offsetCursor));
+    } else {
+      editor.selection = new vscode.Selection(editor.document.positionAt(selectStart), editor.document.positionAt(selectEnd));
+    }
   };
 
   context.subscriptions.push(vscode.commands.registerTextEditorCommand('selectby.regex1', (editor, edit, args) => { processRegEx(1, editor);}) );


### PR DESCRIPTION
If the selection is copied, it is convenient for me that the cursor remains at its original position. Hence the added option. 