### PR TITLE
A fix with revealRange. And allow conditional selection's jump-to-next or extend-to-next for the "forwardNext" pattern.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The ranges are specified in the `settings.json` file for entry `selectby.regexes
     * `backwardInclude`: should the matched **backward** search text be part of the selection (default: true)
     * `forwardInclude`: should the matched **forward** search text be part of the selection (default: true)
     * `forwardNextInclude`: should the matched **forwardNext** search text be part of the selection (default: true)
+    * `forwardNextIncludeExclusivelyWhen`: should the matched **forwardNext** search text be the only selection at the given condition: "always", "jumped" or "never" (default: "never")
+    * `forwardNextInsteadExtendsSelectionIfAny`: should the selection made by a matched **forwardNext** search text, instead, extends from the selection start when the **original+backward+forward** include-range is non-empty. The default behavior is to start a new (jumped) selection from the start of the **forward** match (or the end of current-selection if no match). Note that **forwardNextIncludeExclusivelyWhen** overrides this behavior (default: false)
     * `copyToClipboard`: copy the selection to the clipboard (default: false)
     * `showSelection`: modify the selection to include the new searched positions. Useful if `copyToClipboard` is true. (default: true)
     * `debugNotify`: show a notify message of the used search properties (User and Workspace properties are merged) (default: false)

--- a/extension.js
+++ b/extension.js
@@ -81,6 +81,7 @@ function activate(context) {
     }
     if (getProperty(search, "showSelection", true)) {
       editor.selection = new vscode.Selection(editor.document.positionAt(selectStart), editor.document.positionAt(selectEnd));
+      editor.revealRange(editor.selection);
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,17 @@
                   "type": "boolean",
                   "description": "(Optional) should the matched forwardNext search text be part of the selection (default: true)"
                 },
+                "forwardNextIncludeExclusivelyWhen": {
+                  "type": [
+                    "string",
+                    "boolean"
+                  ],
+                  "description": "(Optional) should the matched forwardNext search text be the only selection at the given condition: \"always\", \"jumped\" or \"never\" (default: \"never\")"
+                },
+                "forwardNextInsteadExtendsSelectionIfAny": {
+                  "type": "boolean",
+                  "description": "(Optional) should the selection made by a matched forwardNext search text, instead, extends from the selection start when the \"original+backward+forward\" include-range is non-empty. The default behavior is to start a new (jumped) selection from the start of the \"forward\" match (or the end of current-selection if no match). Note that \"forwardNextIncludeExclusivelyWhen\" overrides this behavior (default: false)"
+                },
                 "copyToClipboard": {
                   "type": "boolean",
                   "description": "(Optional) copy the selection to the clipboard (default: false)"
@@ -110,7 +121,9 @@
               "dependencies": {
                 "backwardInclude": ["backward"],
                 "forwardInclude": ["forward"],
-                "forwardNextInclude": ["forwardNext"]
+                "forwardNextInclude": ["forwardNext"],
+                "forwardNextIncludeExclusivelyWhen": ["forwardNext"],
+                "forwardNextInsteadExtendsSelectionIfAny": ["forwardNext"]
               }
             }
           },


### PR DESCRIPTION
## Summary

A fix: new text selection is not revealed after command `selectby.regex`
And: Allow conditional selection's jump-to-next or extend-to-next for the "forwardNext" pattern.

For example, support this flow: extends last selection only if last selection is non-empty, and also "forwardNext" give an anchored match at the first search position after "forward" pattern (e.g. "forward" may be a zero-or-more-whitespaces pattern for skipping). Otherwise, make new selection with the "forwardNext" match's range (i.e. a jumped selection).

Two options added for this feature: "forwardNextIncludeExclusivelyWhen" and "forwardNextInsteadExtendsSelectionIfAny".


## Example rule:

```
"selectby.regexes": {
  "Select/extend-to next tuple item": {
    "forward": "\\s*",
    "forwardInclude": false,
    "forwardNext": "\\w+\\s?(,\\s*)?",
    "forwardNextInsteadExtendsSelectionIfAny": true,
    "forwardNextIncludeExclusivelyWhen": "jumped"
  }
}
```

"Select/extend-to next tuple item" may be used to select single/multiple tuple items for swapping orders, removing or copying.

### Run rule result:

```
(  v original cursor after "1," )
(1,`' 2, 3)  -->  (1, `2, '3)  -->  (1, `2, 3')  -->  (1, 2, 3)    -->  (1, 2, 3)    -->  (1, 2, 3)    -->  (1, 2, 3)
(4, 5, 6)         (4, 5, 6)         (4, 5, 6)         (`4, '5, 6)       (`4, 5, '6)       (`4, 5, 6')       (4, 5, 6)`'
```

Terminology:
* `..' : indicate a selection
* -->  :  show the `..' selection after a "Select/extend-to next tuple item" command


## Options meaning from README.md:

* `forwardNextIncludeExclusivelyWhen`: should the matched **forwardNext** search text be the only selection at the given condition: "always", "jumped" or "never" (default: "never")
* `forwardNextInsteadExtendsSelectionIfAny`: should the selection made by a matched **forwardNext** search text, instead, extends from the selection start when the **original+backward+forward** include-range is non-empty. The default behavior is to start a new (jumped) selection from the start of the **forward** match (or the end of current-selection if no match). Note that **forwardNextIncludeExclusivelyWhen** overrides this behavior (default: false)
